### PR TITLE
add syntax highlighting, fix tags, update examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.classpath
+/.project
+/.settings/
 .idea/*
 *~
 *.iml

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,60 +1,80 @@
-== AsciiDoclet
+= Asciidoclet
+John Ericksen <https://github.com/johncarl81>
+v0.1.0
+:source-highlighter: highlightjs
 
-An Asciidoc Javadoc Doclet which allows you to write Javadocs in Asciidoc format.
+Asciidoclet is a Javadoc Doclet that allows you to write Javadoc using the AsciiDoc format.
 
-Traditionally, Javadocs have mixed minor markup with html which, if you're writing for html Javadoc output, becomes
-unreadable and hard to write over time.  This is where lightweight markup languages like Asciidoc thrive.  Asciidoc
+== Introduction
+
+Traditionally, Javadocs have mixed minor markup with HTML which, if you're writing for HTML Javadoc output, becomes
+unreadable and hard to write over time. This is where lightweight markup languages like AsciiDoc thrive. AsciiDoc
 straddles the line between readable markup and beautifully rendered content.
 
-AsciiDoclet encorporates an Asciidoc renderer
-(https://github.com/asciidoctor/asciidoctor[asciidoctor] via
-https://github.com/asciidoctor/asciidoctor-java-integration[asciidoctor-java-integration])
-into a simple Doclet that enables Asciidoc formatting within javadoc comments and tags.
+Asciidoclet encorporates an AsciiDoc renderer
+(https://github.com/asciidoctor/asciidoctor[Asciidoctor] via the
+https://github.com/asciidoctor/asciidoctor-java-integration[Asciidoctor Java integration])
+into a simple Doclet that enables AsciiDoc formatting within Javadoc comments and tags.
 
-=== Example
+== Example
 
-Here's an example of a class with traditional javadoc:
-[code,java]
+Here's an example of a class with traditional Javadoc:
+
+[source,java]
 ----
 /**
- * <h2>Asciidoclet</h2>
+ * <h1>Asciidoclet</h1>
  *
- * <p>Sample Comments including {@code source}</p>
+ * <p>Sample comments that include {@code source code}.</p>
  *
  * <pre>{@code
- * public class Asciidoclet{
- *     public Asciidoclet(){}
- * }
+ * public class Asciidoclet extends Doclet {
+ *     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+ *
+ *     public static boolean start(RootDoc rootDoc) {
+ *         new Asciidoclet().render(rootDoc);
+ *         return Standard.start(rootDoc);
+ *     }
  * }</pre>
  */
-public class Asciidoclet extends Doclet  {}
+public class Asciidoclet extends Doclet {
+}
 ----
 
-and here's the same class with AsciiDoclet:
+and here's the same class with Asciidoclet:
 
-[code,java]
+[source,java]
 ----
 /**
- * Asciidoclet
- * ------------
- * Sample Comments including 'source'
+ * = Asciidoclet
  *
- * [code,java]
- * ----
- * public class Asciidoclet{
- *     public Asciidoclet(){}
+ * Sample comments that include +source code+.
+ *
+ * [source,java]
+ * --
+ * public class Asciidoclet extends Doclet {
+ *     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+ *
+ *     public static boolean start(RootDoc rootDoc) {
+ *         new Asciidoclet().render(rootDoc);
+ *         return Standard.start(rootDoc);
+ *     }
  * }
- * ----
+ * --
+ *
+ * @author https://github.com/johncarl81[John Ericksen]
  */
-public class Asciidoclet extends Doclet  {}
+public class Asciidoclet extends Doclet {
+}
 ----
 
-The result is readable source and beautifully rendered javadocs, the best of both worlds!
+The result is readable source and beautifully rendered Javadocs, the best of both worlds!
 
-=== Usage
-AsciiDoclet may be used via a maven-javadoc-plugin doclet:
-[code,xml]
-----
+== Usage
+
+Asciidoclet may be used via a maven-javadoc-plugin doclet:
+
+[source,xml]
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-javadoc-plugin</artifactId>
@@ -69,12 +89,10 @@ AsciiDoclet may be used via a maven-javadoc-plugin doclet:
         </docletArtifact>
     </configuration>
 </plugin>
-----
 
-=== Licsense
+== License
 
-[code]
-----
+....
 Copyright 2013 John Ericksen
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,4 +106,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-----
+....

--- a/src/main/java/org/asciidoclet/Asciidoclet.java
+++ b/src/main/java/org/asciidoclet/Asciidoclet.java
@@ -1,44 +1,108 @@
 package org.asciidoclet;
 
-import com.sun.javadoc.*;
-import com.sun.tools.doclets.standard.Standard;
-import org.asciidoctor.Asciidoctor;
-
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.SafeMode;
+
+import com.sun.javadoc.AnnotationTypeDoc;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.Doc;
+import com.sun.javadoc.DocErrorReporter;
+import com.sun.javadoc.Doclet;
+import com.sun.javadoc.LanguageVersion;
+import com.sun.javadoc.MemberDoc;
+import com.sun.javadoc.PackageDoc;
+import com.sun.javadoc.RootDoc;
+import com.sun.javadoc.Tag;
+import com.sun.tools.doclets.standard.Standard;
 
 /**
- * Asciidoclet
- * -----------
- * A Javadoc Doclet that uses Asciidoc for rendering javadoc comments.
+ * = Asciidoclet
+ * 
+ * https://github.com/asciidoctor/asciidoclet[Asciidoclet] is a Javadoc Doclet
+ * that uses http://asciidoctor.org[Asciidoctor] (via the
+ * https://github.com/asciidoctor/asciidoctor-java-integration[Asciidoctor Java integration])
+ * to render http://asciidoc.org[AsciiDoc] markup within Javadoc comments.
  *
- * *Examples:*
+ * == Usage
+ * 
+ * AsciiDoclet may be used via a custom doclet in the maven-javadoc-plugin:
  *
- * Code:
- * [code,java]
- * ----
+ * [source,xml]
+ * <plugin>
+ *   <groupId>org.apache.maven.plugins</groupId>
+ *   <artifactId>maven-javadoc-plugin</artifactId>
+ *   <version>2.9</version>
+ *   <configuration>
+ *     <source>1.7</source>
+ *     <doclet>org.asciidoclet.Asciidoclet</doclet>
+ *     <docletArtifact>
+ *       <groupId>org.asciidoclet</groupId>
+ *       <artifactId>asciidoclet</artifactId>
+ *       <version>${asciidoclet.version}</version>
+ *     </docletArtifact>
+ *   </configuration>
+ * </plugin>
+ *
+ * == Examples
+ * 
+ * Code block (with syntax highlighting added by CodeRay)::
+ * +
+ * [source,java]
+ * --
  * /**
- *  * Asciidoclet comments
+ *  * = Asciidoclet
  *  *
+ *  * A Javadoc Doclet that uses http://asciidoctor.org[Asciidoctor]
+ *  * to render http://asciidoc.org[AsciiDoc] markup in Javadoc comments.
+ *  *
+ *  * {@literal @}author https://github.com/johncarl81[John Ericksen]
  *  *{@literal /}
- * public class Asciidoclet{
- *     public Asciidoclet(){}
+ * public class Asciidoclet extends Doclet {
+ *     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create(); // <1>
+ *
+ *     public static boolean start(RootDoc rootDoc) {
+ *         new Asciidoclet().render(rootDoc); // <2>
+ *         return Standard.start(rootDoc);
+ *     }
  * }
- * ----
+ * --
+ * <1> Creates an instance of the Asciidoctor Java integration
+ * <2> Runs Javadoc comment strings through Asciidoctor
  *
- * inline code: `code()`
+ * Inline code:: `code()` or +code()+
  *
+ * Headings::
+ * +
+ * --
+ * [float]
  * = Heading 1
+ * [float]
  * == Heading 2
+ * [float]
  * === Heading 3
+ * [float]
  * ==== Heading 4
+ * [float]
+ * ===== Heading 5
+ * --
  *
- * Doc Writer <doc@example.com>
+ * Links::
+ * Doc Writer <doc@example.com> +
+ * http://asciidoc.org[AsciiDoc] is a lightweight markup language. +
+ * Learn more about it at http://asciidoctor.org. +
  *
- * An introduction to http://asciidoc.org[AsciiDoc].
- *
- * .Bulleted
+ * Bullets::
+ * +
+ * --
+ * .Unnumbered
  * * bullet
  * * bullet
  * - bullet
@@ -56,44 +120,88 @@ import java.util.Set;
  * *** bullet
  * ** bullet
  * * bullet
+ * --
+ * +
+ * --
+ * .Numbered
+ * . bullet
+ * . bullet
+ * .. bullet
+ * .. bullet
+ * . bullet
+ * .. bullet
+ * ... bullet
+ * ... bullet
+ * .... bullet
+ * .... bullet
+ * ... bullet
+ * ... bullet
+ * .. bullet
+ * .. bullet
+ * . bullet
+ * --
  *
- *
+ * Tables::
+ * +
  * .An example table
- * [options="header,footer"]
- * |=======================
- * |Col 1|Col 2      |Col 3
- * |1    |Item 1     |a
- * |2    |Item 2     |b
- * |3    |Item 3     |c
- * |6    |Three items|d
- * |=======================
+ * [cols="3", options="header"]
+ * |===
+ * |Column 1
+ * |Column 2
+ * |Column 3
+ * 
+ * |1
+ * |Item 1
+ * |a
+ * 
+ * |2
+ * |Item 2
+ * |b
+ * 
+ * |3
+ * |Item 3
+ * |c
+ * |===
  *
+ * Sidebar block::
+ * +
  * .Optional Title
  * ****
  * *Sidebar* Block
  *
- * Use: sidebar notes :)
+ * Usage: Notes in a sidebar, naturally.
  * ****
  *
- * IMPORTANT: Important.
+ * Admonitions::
+ * +
+ * IMPORTANT: Check this out!
  *
- * @author John Ericksen
- * @version 0.1
+ * @author https://github.com/johncarl81[John Ericksen]
+ * @version 0.1.0
  * @see org.asciidoclet.Asciidoclet
- * @since 0.1
+ * @since 0.1.0
  * @serial (or @serialField or @serialData)
- * @author John Ericksen
  */
-public class Asciidoclet extends Doclet  {
+public class Asciidoclet extends Doclet {
 
     private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 
+    private final AttributesBuilder attributesBuilder = AttributesBuilder.attributes()
+        .attribute("icons", null)
+        .attribute("idprefix", "")
+        .attribute("notitle", null)
+        .attribute("source-highlighter", "coderay")
+        .attribute("coderay-css", "style");
+
+    private final OptionsBuilder optionsBuilder = OptionsBuilder.options()
+        .safe(SafeMode.SAFE).backend("html5").eruby("erubis");
+
+    private final Pattern inlineContentRe = Pattern.compile("(?s).*?<p>\\s*(.*?)\\s*</p>.*");
+    
     /**
-     * Example usage:
-     * [code,java]
-     * ----
-     * exampleDepreciated("do not use");
-     * ----
+     * .Example usage
+     * [source,java]
+     * exampleDeprecated("do not use");
      *
      * @deprecated for example purposes
      * @exception Exception example
@@ -101,12 +209,15 @@ public class Asciidoclet extends Doclet  {
      * @serialData something else
      * @link Asciidoclet
      */
-    public static void exampleDepreciated(String field) throws Exception{
+    public static void exampleDeprecated(String field) throws Exception{
         //noop
     }
 
     /**
-     * Javadoc spec requirement.
+     * Sets the language version to Java 5.
+     *
+     * _Javadoc spec requirement._
+     *
      * @return language version number
      */
     @SuppressWarnings("UnusedDeclaration")
@@ -115,7 +226,10 @@ public class Asciidoclet extends Doclet  {
     }
 
     /**
-     * Javadoc spec requirement.
+     * Sets the option length to the standard Javadoc option length.
+     *
+     * _Javadoc spec requirement._
+     *
      * @param option input option
      * @return length of required parameters
      */
@@ -125,7 +239,10 @@ public class Asciidoclet extends Doclet  {
     }
 
     /**
-     * Javadoc spec requirement.  Starting point of Javadoc render.
+     * The starting point of Javadoc render.
+     *
+     * _Javadoc spec requirement._
+     *
      * @param rootDoc input class documents
      * @return success
      */
@@ -137,7 +254,10 @@ public class Asciidoclet extends Doclet  {
     }
 
     /**
-     * Javadoc spec requirement.  Handles the input options.
+     * Processes the input options by delegating to the standard handler.
+     *
+     * _Javadoc spec requirement._
+     *
      * @param options input option array
      * @param errorReporter error handling
      * @return success
@@ -149,6 +269,7 @@ public class Asciidoclet extends Doclet  {
 
     /**
      * Renders the input document.
+     *
      * @param rootDoc input
      */
     private void render(RootDoc rootDoc) {
@@ -164,6 +285,7 @@ public class Asciidoclet extends Doclet  {
 
     /**
      * Renders an individual class.
+     *
      * @param doc input
      */
     private void renderClass(ClassDoc doc) {
@@ -187,6 +309,7 @@ public class Asciidoclet extends Doclet  {
 
     /**
      * Renders a generic document (class, field, method, etc)
+     *
      * @param doc input
      */
     private void renderDoc(Doc doc) {
@@ -201,7 +324,8 @@ public class Asciidoclet extends Doclet  {
     }
 
     /**
-     * Renders a document tag
+     * Renders a document tag in the standard way.
+     *
      * @param tag input
      * @param buffer output buffer
      */
@@ -209,12 +333,32 @@ public class Asciidoclet extends Doclet  {
         //print out directly
         buffer.append(tag.name());
         buffer.append(" ");
-        buffer.append(render(tag.text()));
+        // switch to doctype=inline to render tag text once Asciidoctor #328 is resolved
+        String renderedText = render(tag.text());
+        Matcher inlineContentMatcher = inlineContentRe.matcher(renderedText);
+        if (inlineContentMatcher.matches()) {
+        	buffer.append(inlineContentMatcher.group(1));
+        }
+        else {
+        	buffer.append(tag.text());
+        }
     }
 
-    private String render(String input){
-        // Replace "\n " to remove default javadoc space.
-        String reworked = input.trim().replaceAll("\n ", "\n");
-        return asciidoctor.render(reworked, Collections.<String, Object>emptyMap());
+    /**
+     * Renders the input using Asciidoctor.
+     *
+     * The source is first cleaned by stripping any trailing space after an
+     * end line (e.g., `"\n "`), which gets left behind by the Javadoc
+     * processor.
+     *
+     * @param input AsciiDoc source
+     * @return content rendered by Asciidoctor
+     */
+    private String render(String input) {
+        // Replace "\n " to remove default Javadoc space.
+        String cleanedInput = input.trim().replaceAll("\n ", "\n")
+            .replaceAll("\\{@literal (.*?)}", "$1");
+        Map<String, Object> options = optionsBuilder.attributes(attributesBuilder.asMap()).asMap();
+        return asciidoctor.render(cleanedInput, options);
     }
 }


### PR DESCRIPTION
- add syntax highlighting using by CodeRay
- preprocess {@literal *} tags before sending to Asciidoctor
- don't use Asciidoctor on tag content (the output breaks Javadoc)
- reorg the examples as a definition list
- add Eclipse project files to gitignore
