### PR TITLE
fix groupId in example maven configuration

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -109,7 +109,7 @@ Asciidoclet may be used via a +maven-javadoc-plugin+ doclet:
         <source>1.7</source>
         <doclet>org.asciidoctor.Asciidoclet</doclet>
         <docletArtifact>
-            <groupId>org.asciidoclet</groupId>
+            <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoclet</artifactId>
             <version>${asciidoclet.version}</version>
         </docletArtifact>


### PR DESCRIPTION
The example maven configuration snippet uses 'org.asciidoc' as the groupid, instead of 'org.asciidoctor'.
