### PR TITLE
Fix #21, incorrect javadoc summary lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>17.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.9</version>

--- a/src/main/java/org/asciidoctor/Asciidoclet.java
+++ b/src/main/java/org/asciidoctor/Asciidoclet.java
@@ -4,14 +4,11 @@ import com.sun.javadoc.DocErrorReporter;
 import com.sun.javadoc.Doclet;
 import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.RootDoc;
-import org.asciidoctor.asciidoclet.AsciidoctorRenderer;
-import org.asciidoctor.asciidoclet.DocletIterator;
-import org.asciidoctor.asciidoclet.DocletRenderer;
-import org.asciidoctor.asciidoclet.StandardAdapter;
+import org.asciidoctor.asciidoclet.*;
 
 /**
  * = Asciidoclet
- * 
+ *
  * https://github.com/asciidoctor/asciidoclet[Asciidoclet] is a Javadoc Doclet
  * that uses http://asciidoctor.org[Asciidoctor] (via the
  * https://github.com/asciidoctor/asciidoctor-java-integration[Asciidoctor Java integration])
@@ -222,10 +219,13 @@ public class Asciidoclet extends Doclet {
     @SuppressWarnings("UnusedDeclaration")
     public static boolean start(RootDoc rootDoc) {
         String baseDir = getBaseDir(rootDoc.options());
-        DocletRenderer renderer = new AsciidoctorRenderer(baseDir);
-        iterator.render(rootDoc, renderer);
-
-        return standardAdapter.start(rootDoc);
+        AsciidoctorRenderer renderer = new AsciidoctorRenderer(baseDir, rootDoc);
+        try {
+            iterator.render(rootDoc, renderer);
+            return standardAdapter.start(rootDoc);
+        } finally {
+            renderer.cleanup();
+        }
     }
 
     /**

--- a/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorRenderer.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorRenderer.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.asciidoclet;
 
 import com.sun.javadoc.Doc;
+import com.sun.javadoc.DocErrorReporter;
 import com.sun.javadoc.Tag;
 import org.asciidoctor.*;
 
@@ -27,9 +28,10 @@ public class AsciidoctorRenderer implements DocletRenderer {
 
     private final Asciidoctor asciidoctor;
     private final String baseDir;
+    private final OutputTemplates templates;
 
-    public AsciidoctorRenderer(String baseDir) {
-        this(baseDir, create());
+    public AsciidoctorRenderer(String baseDir, DocErrorReporter errorReporter) {
+        this(baseDir, new OutputTemplates(errorReporter), create());
     }
 
     /**
@@ -38,9 +40,10 @@ public class AsciidoctorRenderer implements DocletRenderer {
      * @param baseDir
      * @param asciidoctor
      */
-    protected AsciidoctorRenderer(String baseDir, Asciidoctor asciidoctor) {
+    protected AsciidoctorRenderer(String baseDir, OutputTemplates templates, Asciidoctor asciidoctor) {
         this.baseDir = baseDir;
         this.asciidoctor = asciidoctor;
+        this.templates = templates;
     }
 
     /**
@@ -61,6 +64,10 @@ public class AsciidoctorRenderer implements DocletRenderer {
             buffer.append('\n');
         }
         doc.setRawCommentText(buffer.toString());
+    }
+
+    public void cleanup() {
+        templates.delete();
     }
 
     /**
@@ -100,6 +107,7 @@ public class AsciidoctorRenderer implements DocletRenderer {
         if(inline){
             optionsBuilder.docType(INLINE_DOCTYPE);
         }
+        templates.addToOptions(optionsBuilder);
 
         return asciidoctor.render(cleanJavadocInput(input), optionsBuilder.get());
     }

--- a/src/main/java/org/asciidoctor/asciidoclet/OutputTemplates.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/OutputTemplates.java
@@ -1,0 +1,61 @@
+package org.asciidoctor.asciidoclet;
+
+import com.google.common.io.ByteSink;
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+import com.sun.javadoc.DocErrorReporter;
+import org.asciidoctor.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Sets up a temporary directory containing output templates for use by Asciidoctor.
+ */
+class OutputTemplates {
+
+    private final File templateDir;
+    private final DocErrorReporter errorReporter;
+
+    static final String[] templateNames = new String[] {
+            "section.html.haml",
+            "block_paragraph.html.haml"
+    };
+
+    OutputTemplates(DocErrorReporter errorReporter) {
+        this.errorReporter = errorReporter;
+        this.templateDir = prepareTemplateDir();
+    }
+
+    void addToOptions(OptionsBuilder optionsBuilder) {
+        if (templateDir != null) optionsBuilder.templateDir(templateDir);
+    }
+
+    void delete() {
+        if (templateDir != null) {
+            for (String templateName : templateNames) new File(templateDir, templateName).delete();
+            templateDir.delete();
+        }
+    }
+
+    private File prepareTemplateDir() {
+        // copy our template resources to the templateDir so Asciidoctor can use them.
+        File templateDir = Files.createTempDir();
+        try {
+            for (String templateName : templateNames) prepareTemplate(templateDir, templateName);
+            return templateDir;
+        } catch (IOException e) {
+            errorReporter.printWarning("Failed to prepare templates: " + e.getLocalizedMessage());
+            return null;
+        }
+    }
+
+    private void prepareTemplate(File templateDir, String template) throws IOException {
+        URL src = getClass().getClassLoader().getResource("templates/" + template);
+        if (src == null) throw new IOException("Could not find template " + template);
+        ByteSink dest = Files.asByteSink(new File(templateDir, template));
+        Resources.asByteSource(src).copyTo(dest);
+    }
+
+}

--- a/src/main/resources/templates/block_paragraph.html.haml
+++ b/src/main/resources/templates/block_paragraph.html.haml
@@ -1,0 +1,1 @@
+%p{:id=>@id, :class=>(attr 'role')}= content

--- a/src/main/resources/templates/section.html.haml
+++ b/src/main/resources/templates/section.html.haml
@@ -1,0 +1,8 @@
+-# Simplified section code from lib/asciidoctor/converter/html5.rb
+- @htag = %(h#{level + 1})
+- haml_tag @htag, title, :id => id
+- if level == 1
+  .sectionbody
+    = content
+- else    
+  = content

--- a/src/test/java/org/asciidoctor/asciidoclet/AsciidoctorRendererTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/AsciidoctorRendererTest.java
@@ -23,7 +23,7 @@ public class AsciidoctorRendererTest {
     @Before
     public void setup(){
         mockAsciidoctor = mock(Asciidoctor.class);
-        renderer = new AsciidoctorRenderer(BASE_DIR, mockAsciidoctor);
+        renderer = new AsciidoctorRenderer(BASE_DIR, mock(OutputTemplates.class), mockAsciidoctor);
     }
 
     @Test


### PR DESCRIPTION
- Use simpler section & paragraph output templates so javadoc can correctly
  extract the first sentence for its package, class & method summaries.
- Templates are bundled as resources in asciidoclet.jar then written to a
  tmp dir on javadoc execution where Asciidoctor can find them.
- Added Guava dependency to simplify copying of resources.
