### PR TITLE
resolves #32 align options with Asciidoctor ecosystem

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -120,10 +120,10 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet:
         </docletArtifact>
         <overview>src/main/java/overview.adoc</overview>
         <additionalparam>
-          -include-basedir ${project.basedir}
-          -attributes "name=${project.name}; \
-                       version=${project.version}; \
-                       title-link=http://example.com[${project.name} ${project.version}]"
+          --base-dir ${project.basedir}
+          --attributes "name=${project.name}; \
+                        version=${project.version}; \
+                        title-link=http://example.com[${project.name} ${project.version}]"
         </additionalparam>
     </configuration>
 </plugin>
@@ -147,8 +147,8 @@ javadoc {
     options.docletpath = configurations.asciidoclet.files.asType(List)
     options.doclet = 'org.asciidoctor.Asciidoclet'
     options.overview = "src/main/java/overview.adoc"
-    options.addStringOption('include-basedir', "${projectDir}")
-    options.addStringOption('attributes',
+    options.addStringOption('-base-dir', "${projectDir}")
+    options.addStringOption('-attributes',
             "name=${project.name};" +
             "version=${project.version};" +
             "title-link=http://example.com[${project.name} ${project.version}]")
@@ -165,8 +165,8 @@ Asciidoclet may be used via a doclet element in Ant's `javadoc` task:
          sourcepath="src"
          overview="src/overview.adoc">
   <doclet name="org.asciidoctor.Asciidoclet" pathref="asciidoclet.classpath"> <!--1-->
-    <param name="-include-basedir" value="${basedir}"/>
-    <param name="-attributes"
+    <param name="--base-dir" value="${basedir}"/>
+    <param name="--attributes"
            value="name=${ant.project.name};
                   version=${version};
                   title-link=http://example.com[${ant.project.name} ${version}]"/>
@@ -180,11 +180,11 @@ using http://ant.apache.org/ivy/[Ivy] or similar.
 === Doclet Options
 // tag::doclet-options[]
 
--include-basedir <dir>::
+--base-dir <dir>::
 Sets the base directory that will be used to resolve relative path names in Asciidoc `include::` directives.
 This should be set to the project's root directory.
 
--attributes "key[=value]; ..."::
+--attributes "key[=value]; ..."::
 Sets http://asciidoctor.org/docs/user-manual/#attributes[document attributes^] that will be expanded in javadoc comments.
 The argument is a string containing attributes in the form of `key`, `key!` or `key=value`, separated by semicolons.
 +
@@ -194,7 +194,7 @@ Use `key!` to unset an attribute, and `key=value@` to allow attributes to be ove
 The document attribute `javadoc` is set automatically by the doclet. 
 This may be useful for conditionally selecting content when using the same Asciidoc file for javadoc and other documentation.
 
--attributes-file <file>::
+--attributes-file <file>::
 Reads http://asciidoctor.org/docs/user-manual/#attributes[document attributes^] from an Asciidoc file.
 The attributes will be expanded in javadoc comments.
 +

--- a/pom.xml
+++ b/pom.xml
@@ -128,10 +128,10 @@
                         <version>${project.version}</version>
                     </docletArtifact>
                     <additionalparam> <!--1-->
-                      -include-basedir ${project.basedir}
-                      -attributes "idseparator=-; project_name=${project.name}; \
-                                   project_version=${project.version}; \
-                                   project_desc=${project.description}"
+                      --base-dir ${project.basedir}
+                      --attributes "project_name=${project.name}; \
+                                    project_version=${project.version}; \
+                                    project_desc=${project.description}"
                     </additionalparam>
                     <linksource>true</linksource>
                     <overview>src/main/java/overview.adoc</overview> <!--2-->

--- a/src/main/java/org/asciidoctor/Asciidoclet.java
+++ b/src/main/java/org/asciidoctor/Asciidoclet.java
@@ -271,7 +271,7 @@ public class Asciidoclet extends Doclet {
     }
 
     private boolean postProcess() {
-        if (docletOptions.stylesheetFile().isPresent()) return true;
+        if (docletOptions.stylesheet().isPresent()) return true;
         return stylesheets.copy();
     }
 }

--- a/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorRenderer.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorRenderer.java
@@ -55,7 +55,7 @@ public class AsciidoctorRenderer implements DocletRenderer {
 
     private Options buildOptions(DocletOptions docletOptions, DocErrorReporter errorReporter) {
         OptionsBuilder opts = defaultOptions();
-        if (docletOptions.includeBasedir().isPresent()) opts.baseDir(docletOptions.includeBasedir().get());
+        if (docletOptions.baseDir().isPresent()) opts.baseDir(docletOptions.baseDir().get());
         if (templates.isPresent()) opts.templateDir(templates.get().templateDir());
         opts.attributes(buildAttributes(docletOptions, errorReporter));
         return opts.get();

--- a/src/main/java/org/asciidoctor/asciidoclet/AttributesLoader.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AttributesLoader.java
@@ -65,7 +65,7 @@ class AttributesLoader {
                 .safe(SafeMode.SAFE)
                 .eruby("erubis")
                 .attributes(existingAttrs);
-        if (docletOptions.includeBasedir().isPresent()) options.baseDir(docletOptions.includeBasedir().get());
+        if (docletOptions.baseDir().isPresent()) options.baseDir(docletOptions.baseDir().get());
         Map<String,Object> parsed = asciidoctor.readDocumentStructure(in, options.get().map()).getHeader().getAttributes();
         // workaround for https://github.com/asciidoctor/asciidoctorj/pull/169
         return new HashMap<String,Object>(parsed);

--- a/src/main/java/org/asciidoctor/asciidoclet/DocletOptions.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/DocletOptions.java
@@ -16,11 +16,11 @@ import java.util.List;
 public class DocletOptions {
     public static final String ENCODING = "-encoding";
     public static final String OVERVIEW = "-overview";
-    public static final String INCLUDE_BASEDIR = "-include-basedir";
-    public static final String STYLESHEETFILE = "-stylesheetfile";
+    public static final String BASEDIR = "--base-dir";
+    public static final String STYLESHEET = "--stylesheet";
     public static final String DESTDIR = "-d";
-    public static final String ATTRIBUTES = "-attributes";
-    public static final String ATTRIBUTES_FILE = "-attributes-file";
+    public static final String ATTRIBUTES = "--attributes";
+    public static final String ATTRIBUTES_FILE = "--attributes-file";
 
     private final Optional<File> basedir;
     private final Optional<File> overview;
@@ -46,13 +46,13 @@ public class DocletOptions {
         ImmutableList.Builder<String> attrs = ImmutableList.builder();
         for (String[] option : options) {
             if (option.length > 0) {
-                if (INCLUDE_BASEDIR.equals(option[0])) {
+                if (BASEDIR.equals(option[0])) {
                     basedir = new File(option[1]);
                 }
                 else if (OVERVIEW.equals(option[0])) {
                     overview = new File(option[1]);
                 }
-                else if (STYLESHEETFILE.equals(option[0])) {
+                else if (STYLESHEET.equals(option[0])) {
                     stylesheet = new File(option[1]);
                 }
                 else if (DESTDIR.equals(option[0])) {
@@ -83,11 +83,11 @@ public class DocletOptions {
         return overview;
     }
 
-    public Optional<File> stylesheetFile() {
+    public Optional<File> stylesheet() {
         return stylesheet;
     }
 
-    public Optional<File> includeBasedir() {
+    public Optional<File> baseDir() {
         return basedir;
     }
 
@@ -115,8 +115,8 @@ public class DocletOptions {
     public static boolean validOptions(String[][] options, DocErrorReporter errorReporter, StandardAdapter standardDoclet) {
         DocletOptions docletOptions = new DocletOptions(options);
 
-        if (!docletOptions.includeBasedir().isPresent()) {
-            errorReporter.printWarning(INCLUDE_BASEDIR + " must be present for includes or file reference features.");
+        if (!docletOptions.baseDir().isPresent()) {
+            errorReporter.printWarning(BASEDIR + " must be present for includes or file reference features to work properly.");
         }
 
         Optional<File> attrsFile = docletOptions.attributesFile();
@@ -128,7 +128,7 @@ public class DocletOptions {
     }
 
     public static int optionLength(String option, StandardAdapter standardDoclet) {
-        if (INCLUDE_BASEDIR.equals(option)) {
+        if (BASEDIR.equals(option)) {
             return 2;
         }
         if (ATTRIBUTES.equals(option)) {

--- a/src/test/java/org/asciidoctor/AsciidocletTest.java
+++ b/src/test/java/org/asciidoctor/AsciidocletTest.java
@@ -35,7 +35,7 @@ public class AsciidocletTest {
 
     @Test
     public void testIncludeBaseDirOptionLength(){
-        assertEquals(2, Asciidoclet.optionLength(DocletOptions.INCLUDE_BASEDIR, mockAdapter));
+        assertEquals(2, Asciidoclet.optionLength(DocletOptions.BASEDIR, mockAdapter));
 
         verifyZeroInteractions(mockAdapter);
         verifyZeroInteractions(mockIterator);
@@ -55,7 +55,7 @@ public class AsciidocletTest {
     @Test
     public void testValidBaseDirOption(){
         DocErrorReporter mockReporter = mock(DocErrorReporter.class);
-        String[][] inputOptions = new String[][]{{DocletOptions.INCLUDE_BASEDIR, ""}};
+        String[][] inputOptions = new String[][]{{DocletOptions.BASEDIR, ""}};
 
         when(mockAdapter.validOptions(inputOptions, mockReporter)).thenReturn(true);
 
@@ -97,7 +97,7 @@ public class AsciidocletTest {
     @Test
     public void testStart(){
         RootDoc mockDoc = mock(RootDoc.class);
-        String[][] options = new String[][]{{DocletOptions.INCLUDE_BASEDIR, "test"}};
+        String[][] options = new String[][]{{DocletOptions.BASEDIR, "test"}};
 
         when(mockDoc.options()).thenReturn(options);
         when(mockAdapter.start(mockDoc)).thenReturn(true);
@@ -112,7 +112,7 @@ public class AsciidocletTest {
     @Test
     public void testStylesheetOverride(){
         RootDoc mockDoc = mock(RootDoc.class);
-        String[][] options = new String[][]{{DocletOptions.STYLESHEETFILE, "test"}};
+        String[][] options = new String[][]{{DocletOptions.STYLESHEET, "test"}};
 
         when(mockDoc.options()).thenReturn(options);
         when(mockAdapter.start(mockDoc)).thenReturn(true);

--- a/src/test/java/org/asciidoctor/asciidoclet/AttributesLoaderTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/AttributesLoaderTest.java
@@ -40,7 +40,7 @@ public class AttributesLoaderTest {
     @Test
     public void testOnlyCommandLineAttributes() {
         DocletOptions options = new DocletOptions(new String[][] {
-                { "-attributes", "foo=bar; foo2=foo-two; not!; override=override@" }
+                { "--attributes", "foo=bar; foo2=foo-two; not!; override=override@" }
         });
         AttributesLoader loader = new AttributesLoader(asciidoctor, options, mockErrorReporter);
 
@@ -59,7 +59,7 @@ public class AttributesLoaderTest {
         File attrsFile = createTempFile("attrs.adoc", ATTRS);
 
         DocletOptions options = new DocletOptions(new String[][] {
-                { "-attributes-file", attrsFile.getAbsolutePath() }
+                { "--attributes-file", attrsFile.getAbsolutePath() }
         });
         AttributesLoader loader = new AttributesLoader(asciidoctor, options, mockErrorReporter);
 
@@ -77,8 +77,8 @@ public class AttributesLoaderTest {
         File attrsFile = createTempFile("attrs.adoc", ATTRS);
 
         DocletOptions options = new DocletOptions(new String[][] {
-                { "-attributes", "foo=bar; not!; override=override@" },
-                { "-attributes-file", attrsFile.getAbsolutePath() }
+                { "--attributes", "foo=bar; not!; override=override@" },
+                { "--attributes-file", attrsFile.getAbsolutePath() }
         });
         AttributesLoader loader = new AttributesLoader(asciidoctor, options, mockErrorReporter);
 
@@ -98,8 +98,8 @@ public class AttributesLoaderTest {
         createTempFile("attrs-include.adoc", ATTRS);
 
         DocletOptions options = new DocletOptions(new String[][] {
-                { "-attributes-file", attrsFile.getAbsolutePath() },
-                { "-include-basedir", attrsFile.getParentFile().getAbsolutePath() },
+                { "--attributes-file", attrsFile.getAbsolutePath() },
+                { "--base-dir", attrsFile.getParentFile().getAbsolutePath() },
 
         });
         AttributesLoader loader = new AttributesLoader(asciidoctor, options, mockErrorReporter);
@@ -119,9 +119,9 @@ public class AttributesLoaderTest {
         createTempFile("foo", "attrs-include.adoc", ATTRS);
 
         DocletOptions options = new DocletOptions(new String[][] {
-                { "-attributes-file", attrsFile.getAbsolutePath() },
-                { "-include-basedir", attrsFile.getParentFile().getAbsolutePath() },
-                { "-attributes", "includedir=foo" },
+                { "--attributes-file", attrsFile.getAbsolutePath() },
+                { "--base-dir", attrsFile.getParentFile().getAbsolutePath() },
+                { "--attributes", "includedir=foo" },
 
         });
         AttributesLoader loader = new AttributesLoader(asciidoctor, options, mockErrorReporter);

--- a/src/test/java/org/asciidoctor/asciidoclet/DocletOptionsTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/DocletOptionsTest.java
@@ -12,8 +12,8 @@ public class DocletOptionsTest {
 
     @Test
     public void testGetBaseDir(){
-        assertFalse(DocletOptions.NONE.includeBasedir().isPresent());
-        assertEquals("test", new DocletOptions(new String[][]{{INCLUDE_BASEDIR, "test"}}).includeBasedir().get().getName());
+        assertFalse(DocletOptions.NONE.baseDir().isPresent());
+        assertEquals("test", new DocletOptions(new String[][]{{BASEDIR, "test"}}).baseDir().get().getName());
     }
 
     @Test
@@ -32,8 +32,8 @@ public class DocletOptionsTest {
 
     @Test
     public void testStylesheetFile() {
-        assertFalse(DocletOptions.NONE.stylesheetFile().isPresent());
-        assertEquals("foo.css", new DocletOptions(new String[][]{{STYLESHEETFILE, "foo.css"}}).stylesheetFile().get().getName());
+        assertFalse(DocletOptions.NONE.stylesheet().isPresent());
+        assertEquals("foo.css", new DocletOptions(new String[][]{{STYLESHEET, "foo.css"}}).stylesheet().get().getName());
     }
 
     @Test


### PR DESCRIPTION
- use double-hyphen prefix for long options (where possible)
- rename "include-basedir" to just "basedir"
- rename "stylesheetfile" to just "stylesheet"
