### PR TITLE
Add OpenJDK8 to Travis CI, remove OpenJDK 6, Oracle JDK 7 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: java
 sudo: false
+addons:
+  apt:
+    update:
+      - true
+    packages:
+      - openjdk-6-jdk
 jdk:
   - oraclejdk8
   - openjdk8
@@ -7,7 +13,3 @@ jdk:
   - openjdk6
 notifications:
   irc: "irc.freenode.org#asciidoctor"
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk8
   - openjdk7
   - openjdk6
 notifications:
   irc: "irc.freenode.org#asciidoctor"
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk7
+  - openjdk8
   - openjdk7
   - openjdk6
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: java
 sudo: false
-addons:
-  apt:
-    update:
-      - true
-    packages:
-      - openjdk-6-jdk
 jdk:
   - oraclejdk8
   - openjdk8
   - openjdk7
-  - openjdk6
 notifications:
   irc: "irc.freenode.org#asciidoctor"


### PR DESCRIPTION
* Add `openjdk8` to the Travis CI list of build JDKs.
* Remove `openjdk6` as it is no longer installed by default, and I couldn't figure out how to install it.
* Remove `oraclejdk7` as it is no longer supported by Travis or Oracle.

I wanted to add `oraclejdk9` but Asciidoclet currently won't compile under JDK 9.
