### PR TITLE
Update to AsciidoctorJ 1.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.asciidoctor</groupId>
     <artifactId>asciidoclet</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.5-SNAPSHOT</version>
+    <version>1.5.7-SNAPSHOT</version>
 
     <name>AsciiDoc Javadoc Doclet</name>
 
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.7</version>
         </dependency>
         <dependency>
             <groupId>com.sun.tools</groupId>
@@ -56,12 +56,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.13</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
* Upgrade to AsciidoctorJ 1.5.7
* Bump OUR version to 1.5.7-SNAPSHOT to reflect that
* Update to latest slf4j-simple — 1.7.25 
* Update to latest Guava for Java 1.6 - 20.0