### PR TITLE
Replace assembly-plugin with shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,21 +176,18 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.5</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <finalName>${project.build.finalName}-all</finalName>
-                    <appendAssemblyId>false</appendAssemblyId>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>shaded</shadedClassifierName>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>make-assembly</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Replaces the maven-assembly-plugin with the maven-shade-plugin to support a regular (unbundled) dependency and fat-jar (shaded) dependency.  The result are two main jars (in addition to the javadoc and sources jars): `asciidoclet-<VERSION>.jar` and `asciidoclet-<VERSION>-shaded.jar` https://github.com/asciidoctor/asciidoclet/pull/84 https://github.com/asciidoctor/asciidoclet/issues/70 https://github.com/asciidoctor/asciidoclet/issues/38  https://github.com/asciidoctor/asciidoclet/pull/43