### PR TITLE
Set our version to 1.5.6-SNAPSHOT, bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.asciidoctor</groupId>
     <artifactId>asciidoclet</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.5-SNAPSHOT</version>
+    <version>1.5.6-SNAPSHOT</version>
 
     <name>AsciiDoc Javadoc Doclet</name>
 
@@ -56,12 +56,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.13</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
* Set SNAPSHOT version to 1.5.6 to match AsciidoctorJ we’re using
* Bump slf4j to 1.7.25
* Bump Guava to 20.0 (final version that supports Java 1.6)

The plan is to go ahead an release version 1.5.6 and later release a 1.5.7, when #45 and related issues are fixed.
