### PR TITLE
README improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,8 +18,9 @@ ifdef::env-github[]
 :!toc-title:
 endif::[]
 // Refs
+:asciidoclet-version: 1.5.6
 :asciidoclet-src-ref: https://github.com/asciidoctor/asciidoclet
-:asciidoclet-javadoc-ref: https://oss.sonatype.org/service/local/repositories/releases/archive/org/asciidoctor/asciidoclet/1.5.2/asciidoclet-1.5.2-javadoc.jar/!/index.html
+:asciidoclet-javadoc-ref: https://www.javadoc.io/doc/org.asciidoctor/asciidoclet/{asciidoclet-version}
 :asciidoclet-release-ref: http://asciidoctor.org/news/2014/09/09/asciidoclet-1.5.0-released/
 :asciidoc-ref: http://asciidoc.org
 :asciidoctor-java-ref: http://asciidoctor.org/docs/install-and-use-asciidoctor-java-integration/
@@ -30,7 +31,7 @@ endif::[]
 
 ifdef::badges[]
 image:http://img.shields.io/travis/asciidoctor/asciidoclet/master.svg["Build Status", link="https://travis-ci.org/asciidoctor/asciidoclet"]
-image:https://img.shields.io/badge/javadoc.io-1.5.4-blue.svg[Javadoc, link=http://www.javadoc.io/doc/org.asciidoctor/asciidoclet/1.5.4]
+image:https://img.shields.io/badge/javadoc.io-{asciidoclet-version}-blue.svg[Javadoc, link={asciidoclet-javadoc-ref}]
 endif::[]
 
 {asciidoclet-src-ref}[Asciidoclet] is a Javadoc Doclet based on Asciidoctor that lets you write Javadoc in the AsciiDoc syntax.

--- a/README.adoc
+++ b/README.adoc
@@ -21,16 +21,16 @@ endif::[]
 :asciidoclet-version: 1.5.6
 :asciidoclet-src-ref: https://github.com/asciidoctor/asciidoclet
 :asciidoclet-javadoc-ref: https://www.javadoc.io/doc/org.asciidoctor/asciidoclet/{asciidoclet-version}
-:asciidoclet-release-ref: http://asciidoctor.org/news/2014/09/09/asciidoclet-1.5.0-released/
-:asciidoc-ref: http://asciidoc.org
-:asciidoctor-java-ref: http://asciidoctor.org/docs/install-and-use-asciidoctor-java-integration/
+:asciidoclet-release-ref: https://asciidoctor.org/news/2014/09/09/asciidoclet-1.5.0-released/
+:asciidoc-ref: https://asciidoc.org
+:asciidoctor-java-ref: https://asciidoctor.org/docs/install-and-use-asciidoctor-java-integration/
 :asciidoclet-issues-ref: https://github.com/asciidoctor/asciidoclet/issues
 :asciidoctor-src-ref: https://github.com/asciidoctor/asciidoctor
 :asciidoctor-java-src-ref: https://github.com/asciidoctor/asciidoctor-java-integration
-:discuss-ref: http://discuss.asciidoctor.org/
+:discuss-ref: https://discuss.asciidoctor.org/
 
 ifdef::badges[]
-image:http://img.shields.io/travis/asciidoctor/asciidoclet/master.svg["Build Status", link="https://travis-ci.org/asciidoctor/asciidoclet"]
+image:https://img.shields.io/travis/asciidoctor/asciidoclet/master.svg["Build Status", link="https://travis-ci.org/asciidoctor/asciidoclet"]
 image:https://img.shields.io/badge/javadoc.io-{asciidoclet-version}-blue.svg[Javadoc, link={asciidoclet-javadoc-ref}]
 endif::[]
 
@@ -135,7 +135,7 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet:
           --base-dir ${project.basedir}
           --attribute "name=${project.name}"
           --attribute "version=${project.version}"
-          --attribute "title-link=http://example.com[${project.name} ${project.version}]"
+          --attribute "title-link=https://example.com[${project.name} ${project.version}]"
         </additionalparam>
     </configuration>
 </plugin>
@@ -163,7 +163,7 @@ javadoc {
     options.addStringOption "-attribute", // <2>
             "name=${project.name}," +
             "version=${project.version}," +
-            "title-link=http://example.com[${project.name} ${project.version}]")
+            "title-link=https://example.com[${project.name} ${project.version}]")
 }
 ----
 <1> Option names passed to Gradle's `javadoc` task must omit the leading "-", so here "-base-dir" means "--base-dir".
@@ -184,13 +184,13 @@ Asciidoclet may be used via a doclet element in Ant's `javadoc` task:
     <param name="--base-dir" value="${basedir}"/>
     <param name="--attribute" value="name=${ant.project.name}"/>
     <param name="--attribute" value="version=${version}"/>
-    <param name="--attribute" value="title-link=http://example.com[${ant.project.name} ${version}]"/>
+    <param name="--attribute" value="title-link=https://example.com[${ant.project.name} ${version}]"/>
   </doclet>
 </javadoc>
 ----
 
 <1> Assumes a path reference has been defined for Asciidoclet and its dependencies, e.g.
-using http://ant.apache.org/ivy/[Ivy] or similar.
+using https://ant.apache.org/ivy/[Ivy] or similar.
 
 === Doclet Options
 // tag::doclet-options[]
@@ -200,7 +200,7 @@ Sets the base directory that will be used to resolve relative path names in Asci
 This should be set to the project's root directory.
 
 -a, --attribute "name[=value], ..."::
-Sets http://asciidoctor.org/docs/user-manual/#attributes[document attributes^] that will be expanded in Javadoc comments.
+Sets https://asciidoctor.org/docs/user-manual/#attributes[document attributes^] that will be expanded in Javadoc comments.
 The argument is a string containing a single attribute, or multiple attributes separated by commas.
 +
 This option may be used more than once, for example: `-a name=foo -a version=1`.
@@ -218,7 +218,7 @@ The document attribute `javadoc` is set automatically by the doclet.
 This can be used for conditionally selecting content when using the same Asciidoc file for Javadoc and other documentation.
 
 --attributes-file <file>::
-Reads http://asciidoctor.org/docs/user-manual/#attributes[document attributes^] from an Asciidoc file.
+Reads https://asciidoctor.org/docs/user-manual/#attributes[document attributes^] from an Asciidoc file.
 The attributes will be expanded in Javadoc comments.
 +
 If `<file>` is a relative path name, it is assumed to be relative to the `--base-dir` directory.
@@ -286,7 +286,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
* Add `asciidoclet-version` variable and set it to latest version (1.5.6)
* Consistently use `javadoc.io` for JavaDoc
* Replace all occurrences of http:// with https://