### PR TITLE
Upgrade to Guava 24.1.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This upgrade should eliminate the Github security warning.

Other than making sure this compiles and runs tests, I have
not manually reviewed the change lists for Guava or the Asciidoclet code
that is using it. I also didn't test or research using an even newer Guava. I just want the darn Github warning to go away.
