### PR TITLE
(main) Bump AsciidoctorJ to latest v2.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.8.1</version>
+            <version>2.5.12</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -16,6 +16,7 @@
 module asciidoclet {
     requires java.base;
     requires jdk.javadoc;
+    requires asciidoctorj.api;
     requires asciidoctorj;
     exports org.asciidoctor.asciidoclet;
 }

--- a/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorConverter.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorConverter.java
@@ -16,15 +16,19 @@
 package org.asciidoctor.asciidoclet;
 
 import jdk.javadoc.doclet.Reporter;
-import org.asciidoctor.*;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.Options;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.SafeMode;
 import org.asciidoctor.extension.RubyExtensionRegistry;
+import org.asciidoctor.jruby.AsciidoctorJRuby;
 
 import java.io.IOException;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.asciidoctor.Asciidoctor.Factory.create;
 
 /**
  * Doclet converter using and configuring AsciidoctorJ.
@@ -36,7 +40,7 @@ class AsciidoctorConverter {
     static final String MARKER = " \t \t";
 
     private static AttributesBuilder defaultAttributes() {
-        return AttributesBuilder.attributes()
+        return Attributes.builder()
                 .attribute("at", "&#64;")
                 .attribute("slash", "/")
                 .attribute("icons", null)
@@ -51,7 +55,7 @@ class AsciidoctorConverter {
     }
 
     private static OptionsBuilder defaultOptions() {
-        return OptionsBuilder.options()
+        return Options.builder()
                 .safe(SafeMode.SAFE)
                 .backend("html5");
     }
@@ -64,7 +68,14 @@ class AsciidoctorConverter {
     private final Options options;
 
     AsciidoctorConverter(DocletOptions docletOptions, Reporter reporter) {
-        this(docletOptions, reporter, OutputTemplates.create(reporter), create(docletOptions.gemPath()));
+        this(docletOptions, reporter, OutputTemplates.create(reporter), createAsciidoctorInstance(docletOptions.gemPath()));
+    }
+
+    private static Asciidoctor createAsciidoctorInstance(String gemPath) {
+        if (gemPath != null) {
+            return AsciidoctorJRuby.Factory.create(gemPath);
+        }
+        return Asciidoctor.Factory.create();
     }
 
     /**
@@ -169,7 +180,7 @@ class AsciidoctorConverter {
             return "";
         }
         options.setDocType(inline ? INLINE_DOCTYPE : null);
-        return asciidoctor.render(cleanJavadocInput(input), options);
+        return asciidoctor.convert(cleanJavadocInput(input), options);
     }
 
     static String cleanJavadocInput(String input) {

--- a/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorConverter.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorConverter.java
@@ -26,6 +26,7 @@ import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -172,14 +173,15 @@ class AsciidoctorConverter {
      * end line (e.g., `"\n "`), which gets left behind by the Javadoc
      * processor.
      *
-     * @param input AsciiDoc source
+     * @param input  AsciiDoc source
+     * @param inline true to set doc_type to inline, null otherwise
      * @return content rendered by Asciidoctor
      */
     private String convert(String input, boolean inline) {
         if (input.trim().isEmpty()) {
             return "";
         }
-        options.setDocType(inline ? INLINE_DOCTYPE : null);
+        options.setDocType(inline ? INLINE_DOCTYPE : "");
         return asciidoctor.convert(cleanJavadocInput(input), options);
     }
 

--- a/src/main/java/org/asciidoctor/asciidoclet/AttributesLoader.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AttributesLoader.java
@@ -18,18 +18,23 @@ package org.asciidoctor.asciidoclet;
 import jdk.javadoc.doclet.Reporter;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
+import org.asciidoctor.jruby.internal.IOUtils;
 
 import javax.tools.Diagnostic;
 import java.io.File;
+import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.Set;
 
 class AttributesLoader {
@@ -82,15 +87,23 @@ class AttributesLoader {
     }
 
     private Map<String, Object> parseAttributes(Reader in, Map<String, Object> existingAttrs) {
-        OptionsBuilder options = OptionsBuilder.options()
+        OptionsBuilder options = Options.builder()
                 .safe(SafeMode.SAFE)
-                .attributes(existingAttrs);
+                .attributes(existingAttrs)
+                .parseHeaderOnly(true);
         if (docletOptions.baseDir().isPresent()) {
             options.baseDir(docletOptions.baseDir().get());
         }
-        Map<String, Object> parsed = asciidoctor.readDocumentStructure(in, options.get().map()).getHeader().getAttributes();
-        // workaround for https://github.com/asciidoctor/asciidoctorj/pull/169
-        return new HashMap<>(parsed);
+
+        final String content = read(in);
+        final Map<String, Object> parsed = asciidoctor.load(content, options.build()).getAttributes();
+        return parsed;
+    }
+
+    public static String read(Reader reader) {
+        try (Scanner scanner = new Scanner(reader).useDelimiter("\\A")){
+            return scanner.next();
+        }
     }
 
     private Set<String> getUnsetAttributes(List<String> args) {

--- a/src/test/java/org/asciidoctor/asciidoclet/AsciidoctorConverterTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/AsciidoctorConverterTest.java
@@ -27,8 +27,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class AsciidoctorConverterTest {
 
-    // Asciidoctorj < v2.5.12 used OS linebreaks instead of simply \n
-    private static final String LINEBREAK = "\r?\n";
+    private static final String LINEBREAK = "\n";
 
     private AsciidoctorConverter converter;
     private StubReporter reporter = new StubReporter();
@@ -42,13 +41,13 @@ public class AsciidoctorConverterTest {
     @Test
     public void testAtLiteralRender() {
         String actual = converter.convert("{@literal @}Test");
-        assertThat(actual).matches(MARKER + "<p>\\{@literal @}Test</p>" + LINEBREAK);
+        assertThat(actual).isEqualTo(MARKER + "<p>{@literal @}Test</p>" + LINEBREAK);
     }
 
     @Test
     public void testTagRender() {
         String actual = converter.convert("input\n@tagName tagText");
-        assertThat(actual).matches(MARKER + "<p>input</p>" + LINEBREAK + "@tagName tagText" + LINEBREAK);
+        assertThat(actual).isEqualTo(MARKER + "<p>input</p>" + LINEBREAK + "@tagName tagText" + LINEBREAK);
     }
 
     @Test
@@ -60,13 +59,19 @@ public class AsciidoctorConverterTest {
     }
 
     @Test
+    public void testComment() {
+        assertThat(converter.convert("comment\n"))
+                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK);
+    }
+
+    @Test
     public void testParameterWithoutTypeTag() {
         assertThat(converter.convert("comment\n@param p description"))
-                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param p description" + LINEBREAK);
+                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param p description" + LINEBREAK);
         assertThat(converter.convert("comment\n@param p"))
-                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param p" + LINEBREAK);
+                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param p" + LINEBREAK);
         assertThat(converter.convert("comment\n@param"))
-                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param " + LINEBREAK);
+                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param " + LINEBREAK);
     }
 
     @Test
@@ -80,6 +85,6 @@ public class AsciidoctorConverterTest {
         String sourceText = commentText + "\n@param " + param1Text + "\n@param " + param2Text;
 
         assertThat(converter.convert(sourceText))
-                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param <T>" + LINEBREAK + "@param <X> description" + LINEBREAK);
+                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param <T>" + LINEBREAK + "@param <X> description" + LINEBREAK);
     }
 }

--- a/src/test/java/org/asciidoctor/asciidoclet/AsciidoctorConverterTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/AsciidoctorConverterTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class AsciidoctorConverterTest {
 
-    private static final String LINEBREAK = "\n";
+    private static final String LINEBREAK = "\r?\n";
 
     private AsciidoctorConverter converter;
     private StubReporter reporter = new StubReporter();
@@ -41,13 +41,13 @@ public class AsciidoctorConverterTest {
     @Test
     public void testAtLiteralRender() {
         String actual = converter.convert("{@literal @}Test");
-        assertThat(actual).isEqualTo(MARKER + "<p>{@literal @}Test</p>" + LINEBREAK);
+        assertThat(actual).matches(MARKER + "<p>\\{@literal @}Test</p>" + LINEBREAK);
     }
 
     @Test
     public void testTagRender() {
         String actual = converter.convert("input\n@tagName tagText");
-        assertThat(actual).isEqualTo(MARKER + "<p>input</p>" + LINEBREAK + "@tagName tagText" + LINEBREAK);
+        assertThat(actual).matches(MARKER + "<p>input</p>" + LINEBREAK + "@tagName tagText" + LINEBREAK);
     }
 
     @Test
@@ -61,17 +61,17 @@ public class AsciidoctorConverterTest {
     @Test
     public void testComment() {
         assertThat(converter.convert("comment\n"))
-                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK);
+                .matches(MARKER + "<p>comment</p>" + LINEBREAK);
     }
 
     @Test
     public void testParameterWithoutTypeTag() {
         assertThat(converter.convert("comment\n@param p description"))
-                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param p description" + LINEBREAK);
+                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param p description" + LINEBREAK);
         assertThat(converter.convert("comment\n@param p"))
-                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param p" + LINEBREAK);
+                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param p" + LINEBREAK);
         assertThat(converter.convert("comment\n@param"))
-                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param " + LINEBREAK);
+                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param " + LINEBREAK);
     }
 
     @Test
@@ -85,6 +85,6 @@ public class AsciidoctorConverterTest {
         String sourceText = commentText + "\n@param " + param1Text + "\n@param " + param2Text;
 
         assertThat(converter.convert(sourceText))
-                .isEqualTo(MARKER + "<p>comment</p>" + LINEBREAK + "@param <T>" + LINEBREAK + "@param <X> description" + LINEBREAK);
+                .matches(MARKER + "<p>comment</p>" + LINEBREAK + "@param <T>" + LINEBREAK + "@param <X> description" + LINEBREAK);
     }
 }

--- a/src/test/java/org/asciidoctor/asciidoclet/AttributesLoaderTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/AttributesLoaderTest.java
@@ -16,6 +16,7 @@
 package org.asciidoctor.asciidoclet;
 
 import org.asciidoctor.Asciidoctor;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/src/test/java/org/asciidoctor/asciidoclet/AttributesLoaderTest.java
+++ b/src/test/java/org/asciidoctor/asciidoclet/AttributesLoaderTest.java
@@ -16,7 +16,6 @@
 package org.asciidoctor.asciidoclet;
 
 import org.asciidoctor.Asciidoctor;
-import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -30,9 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributesLoaderTest {
 
@@ -49,7 +46,7 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = loader.load();
 
-        assertTrue(attrs.isEmpty());
+        assertThat(attrs).isEmpty();
         reporter.assertNoMoreInteractions();
     }
 
@@ -61,11 +58,13 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = loader.load();
 
-        assertEquals(attrs.get("foo"), "bar");
-        assertEquals(attrs.get("foo2"), "foo-two");
-        assertEquals(attrs.get("override"), "override@");
-        assertFalse(attrs.containsKey("not"));
-        assertTrue(attrs.containsKey("not!"));
+        assertThat(attrs)
+                .containsEntry("foo", "bar")
+                .containsEntry("foo2", "foo-two")
+                .containsEntry("override", "override@")
+                .containsKey("not!");
+        assertThat(attrs)
+                .doesNotContainKey("not");
         reporter.assertNoMoreInteractions();
     }
 
@@ -78,11 +77,13 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = loader.load();
 
-        assertEquals(attrs.get("foo"), "bar");
-        assertEquals(attrs.get("foo2"), "foo two");
-        assertEquals(attrs.get("override"), "override@");
-        assertFalse(attrs.containsKey("not"));
-        assertTrue(attrs.containsKey("not!"));
+        assertThat(attrs)
+                .containsEntry("foo", "bar")
+                .containsEntry("foo2", "foo two")
+                .containsEntry("override", "override@")
+                .containsKey("not!");
+        assertThat(attrs)
+                .doesNotContainKey("not");
         reporter.assertNoMoreInteractions();
     }
 
@@ -96,10 +97,11 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = loader.load();
 
-        assertEquals(attrs.get("foo"), "BAR");
-        assertEquals(attrs.get("foo2"), "BAR-TWO");
-        assertEquals(attrs.get("override"), "OVERRIDE");
-        assertTrue(attrs.containsKey("not"));
+        assertThat(attrs)
+                .containsEntry("foo", "BAR")
+                .containsEntry("foo2", "BAR-TWO")
+                .containsEntry("override", "OVERRIDE")
+                .containsKey("not");
         reporter.assertNoMoreInteractions();
     }
 
@@ -114,11 +116,13 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = new HashMap<>(loader.load());
 
-        assertEquals(attrs.get("foo"), "bar");
-        assertEquals(attrs.get("foo2"), "bar-TWO");
-        assertEquals(attrs.get("override"), "OVERRIDE");
-        assertFalse(attrs.containsKey("not"));
-        assertTrue(attrs.containsKey("not!"));
+        assertThat(attrs)
+                .containsEntry("foo", "bar")
+                .containsEntry("foo2", "bar-TWO")
+                .containsEntry("override", "OVERRIDE")
+                .containsKey("not!");
+        assertThat(attrs)
+                .doesNotContainKey("not");
         reporter.assertNoMoreInteractions();
     }
 
@@ -134,10 +138,12 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = loader.load();
 
-        assertEquals(attrs.get("foo"), "BAR");
-        assertEquals(attrs.get("foo2"), "BAR-TWO");
-        assertEquals(attrs.get("override"), "OVERRIDE");
-        assertTrue(attrs.containsKey("not"));
+        assertThat(attrs)
+                .containsEntry("foo", "BAR")
+                .containsEntry("foo2", "BAR-TWO")
+                .containsEntry("override", "OVERRIDE")
+                .containsKey("not");
+
         reporter.assertNoMoreInteractions();
     }
 
@@ -154,10 +160,12 @@ public class AttributesLoaderTest {
 
         Map<String, Object> attrs = loader.load();
 
-        assertEquals(attrs.get("foo"), "BAR");
-        assertEquals(attrs.get("foo2"), "BAR-TWO");
-        assertEquals(attrs.get("override"), "OVERRIDE");
-        assertTrue(attrs.containsKey("not"));
+        assertThat(attrs)
+                .containsEntry("foo", "BAR")
+                .containsEntry("foo2", "BAR-TWO")
+                .containsEntry("override", "OVERRIDE")
+                .containsKey("not");
+
         reporter.assertNoMoreInteractions();
     }
 


### PR DESCRIPTION
* Avoid setting `null` as `doc_type` which caused NPE.
* Fix Asciidoctor instance creation.
* Avoid the use of deprecated methods. Those that use `Map` are still needed and cannot be removed.
* Rewrite assertions in AttributesLoaderTest to use AssertJ

closes #119