### PR TITLE
(main) Remove maven-shade-plugin to publish original pom (#120)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
                         <mavenExecutorId>forked-path</mavenExecutorId>
                     </configuration>
                 </plugin>
-                <!-- default plugins for build, if not defined in parent-pom -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
@@ -241,23 +240,6 @@
                     <useDefaultExcludes>true</useDefaultExcludes>
                     <strictCheck>true</strictCheck>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.2</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>shaded</shadedClassifierName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The shade-plugin alters the pom.xml removing runtime dependencies. This makes that components consuming asciidoclet cannot resolve required dependencies like AsciidoctorJ, causing conversion to fail.

closes #120