### PR TITLE
Update Usage docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -204,7 +204,7 @@ using https://ant.apache.org/ivy/[Ivy] or similar.
 // tag::doclet-options[]
 
 --base-dir <dir>::
-Sets the base directory that will be used to resolve relative path names in Asciidoc `include::` directives.
+Sets the base directory that will be used to resolve relative path names in AsciiDoc `include::` directives.
 This should be set to the project's root directory.
 
 -a, --attribute "name[=value], ..."::
@@ -223,10 +223,10 @@ Attributes use the same syntax as Asciidoctor command-line attributes:
 --
 +
 The document attribute `javadoc` is set automatically by the doclet.
-This can be used for conditionally selecting content when using the same Asciidoc file for Javadoc and other documentation.
+This can be used for conditionally selecting content when using the same AsciiDoc file for Javadoc and other documentation.
 
 --attributes-file <file>::
-Reads https://asciidoctor.org/docs/user-manual/#attributes[document attributes^] from an Asciidoc file.
+Reads https://asciidoctor.org/docs/user-manual/#attributes[document attributes^] from an AsciiDoc file.
 The attributes will be expanded in Javadoc comments.
 +
 If `<file>` is a relative path name, it is assumed to be relative to the `--base-dir` directory.
@@ -244,13 +244,13 @@ Sets the `GEM_PATH` for Asciidoctor's JRuby runtime.
 This option is only needed when using the `--require` option to load additional gems on the `GEM_PATH`.
 
 -overview <file>::
-Overview documentation can be generated from an Asciidoc file using the standard `-overview` option.
+Overview documentation can be generated from an AsciiDoc file using the standard `-overview` option.
 Files matching [x-]`*.adoc`, [x-]`*.ad`, [x-]`*.asciidoc` or [x-]`*.txt` are processed by Asciidoclet.
 Other files are assumed to be HTML and will be processed by the standard doclet.
 
 --asciidoclet-include <filter>::
 --asciidoclet-exclude <filter>::
-Explicitly include or exclude classes from being processed as Asciidoc comments by ant-style path matching (see https://github.com/azagniotov/ant-style-path-matcher[ant-style-path-matcher]).
+Explicitly include or exclude classes from being processed as AsciiDoc comments by ant-style path matching (see https://github.com/azagniotov/ant-style-path-matcher[ant-style-path-matcher]).
 +
 If `--asciidoclet-include` is specified, only classes and packages matching the include filter are processed.
 Likewise, if `--include` is unspecified, all classes are processed.
@@ -259,7 +259,7 @@ If `--asciidoclet-exclude` is specified, classes matching the filter are not pro
 Both `--asciidoclet-include` and `--asciidoclet-exclude` can be mixed.
 In addition, classes excluded with `--asciidoclet-exclude` or not matching a specified `--asciidoclet-include` may be included by annotating the class level javadoc with `@asciidoclet`.
 Doing so allows writing one class at a time while respecting refactors.
-This feature allows the migration of documentation from HTML to Asciidoc in a piecemeal way.
+This feature allows the migration of documentation from HTML to AsciiDoc in a piecemeal way.
 
 // end::doclet-options[]
 // end::usage[]

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,9 +1,9 @@
 name: asciidoclet
 title: Asciidoclet
-version: '1.5.6'
+version: '2.0'
 asciidoc:
   attributes:
-    asciidoclet-version: 1.5.6
+    asciidoclet-version: 2.0.0
     asciidoclet-src-ref: https://github.com/asciidoctor/asciidoclet
     asciidoclet-javadoc-ref: https://www.javadoc.io/doc/org.asciidoctor/asciidoclet/{asciidoclet-version}
     asciidoclet-release-ref: https://asciidoctor.org/news/2014/09/09/asciidoclet-1.5.0-released/

--- a/docs/modules/ROOT/pages/options.adoc
+++ b/docs/modules/ROOT/pages/options.adoc
@@ -2,7 +2,7 @@
 :url-asciidoctor-attributes: https://asciidoctor.org/docs/user-manual/#attributes
 
 --base-dir <dir>::
-Sets the base directory that will be used to resolve relative path names in Asciidoc `include::` directives.
+Sets the base directory that will be used to resolve relative path names in AsciiDoc `include::` directives.
 This should be set to the project's root directory.
 
 -a, --attribute "name[=value], ..."::
@@ -21,10 +21,10 @@ Attributes use the same syntax as Asciidoctor command-line attributes:
 --
 +
 The document attribute `javadoc` is set automatically by the doclet.
-This can be used for conditionally selecting content when using the same Asciidoc file for Javadoc and other documentation.
+This can be used for conditionally selecting content when using the same AsciiDoc file for Javadoc and other documentation.
 
 --attributes-file <file>::
-Reads {url-asciidoctor-attributes}[document attributes^] from an Asciidoc file.
+Reads {url-asciidoctor-attributes}[document attributes^] from an AsciiDoc file.
 The attributes will be expanded in Javadoc comments.
 +
 If `<file>` is a relative path name, it is assumed to be relative to the `--base-dir` directory.
@@ -42,13 +42,13 @@ Sets the `GEM_PATH` for Asciidoctor's JRuby runtime.
 This option is only needed when using the `--require` option to load additional gems on the `GEM_PATH`.
 
 -overview <file>::
-Overview documentation can be generated from an Asciidoc file using the standard `-overview` option.
+Overview documentation can be generated from an AsciiDoc file using the standard `-overview` option.
 Files matching [x-]`*.adoc`, [x-]`*.ad`, [x-]`*.asciidoc` or [x-]`*.txt` are processed by Asciidoclet.
 Other files are assumed to be HTML and will be processed by the standard doclet.
 
 --asciidoclet-include <filter>::
 --asciidoclet-exclude <filter>::
-Explicitly include or exclude classes from being processed as Asciidoc comments by ant-style path matching (see https://github.com/azagniotov/ant-style-path-matcher[ant-style-path-matcher]).
+Explicitly include or exclude classes from being processed as AsciiDoc comments by ant-style path matching (see https://github.com/azagniotov/ant-style-path-matcher[ant-style-path-matcher]).
 +
 If `--asciidoclet-include` is specified, only classes and packages matching the include filter are processed.
 Likewise, if `--include` is unspecified, all classes are processed.
@@ -57,4 +57,4 @@ If `--asciidoclet-exclude` is specified, classes matching the filter are not pro
 Both `--asciidoclet-include` and `--asciidoclet-exclude` can be mixed.
 In addition, classes excluded with `--asciidoclet-exclude` or not matching a specified `--asciidoclet-include` may be included by annotating the class level javadoc with `@asciidoclet`.
 Doing so allows writing one class at a time while respecting refactors.
-This feature allows the migration of documentation from HTML to Asciidoc in a piecemeal way.
+This feature allows the migration of documentation from HTML to AsciiDoc in a piecemeal way.

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -88,7 +88,12 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Ja
 Asciidoclet may be used via a doclet in the `Javadoc` task:
 
 [source,groovy]
+.Java 17+
 ----
+plugins {
+    id 'java'
+}
+
 configurations {
     asciidoclet
 }
@@ -98,14 +103,24 @@ dependencies {
 }
 
 javadoc {
-    options.docletpath = configurations.asciidoclet.files.asType(List)
-    options.doclet = 'org.asciidoctor.asciidoclet.Asciidoclet'
-    options.overview = "src/main/java/overview.adoc"
-    options.addStringOption "-base-dir", "${projectDir}" // <1>
-    options.addStringOption "-attribute", // <2>
-            "name=${project.name}," +
-            "version=${project.version}," +
-            "title-link=https://example.com[${project.name} ${project.version}]"
+    options {
+        docletpath = configurations.asciidoclet.files.asType(List)
+        doclet = 'org.asciidoctor.asciidoclet.Asciidoclet'
+        overview = "src/main/java/overview.adoc"
+        addStringOption "-base-dir", "${projectDir}" // <1>
+        addStringOption \
+            "-attribute", // <2>
+                "name=${project.name}," +
+                "version=${project.version}," +
+                "title-link=https://example.com[${project.name} ${project.version}]"
+        jFlags \
+            "--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED"
+    }
 }
 ----
 <1> Option names passed to Gradle's `javadoc` task must omit the leading "-", so here "-base-dir" means "--base-dir".

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -1,22 +1,24 @@
 = Usage
-:doclet-class: org.asciidoctor.asciidoclet.Asciidoclet
+:asciidoclet-class: org.asciidoctor.asciidoclet.Asciidoclet
 :maven-javadoc-plugin-version: 3.6.3
 
-Run Javadoc with the `{doclet-class}` doclet class as shown in the example below.
+Run Javadoc with the `{asciidoclet-class}` doclet class as shown in the examples below.
 See
 ifdef::site-gen-antora[xref:options.adoc[]]
 ifndef::site-gen-antora[<<doclet-options>> below]
 for supported options.
 
-NOTE: Asciidoclet must use some internal Java components.
-That requires the use of `exports` and `open` configurations.
+NOTE: Asciidoclet must use some Java runtime internals.
+That requires the use of `exports` and `open` configurations depending on the Java version in use.
 
 == Maven
 
-Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Java versions
+Asciidoclet may be used via a `maven-javadoc-plugin` for the supported Java versions.
+Pay special attention to `<additionalJOptions>` to configure access to Java internals.
+
+== Java 11 example
 
 [source,xml,subs="attributes+"]
-.Java 11
 ----
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
@@ -24,14 +26,7 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Ja
     <version>{maven-javadoc-plugin-version}</version>
     <configuration>
         <source>11</source>
-        <additionalJOptions>
-            <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
-            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
-            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
-            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
-            <additionalJOption>-Xdoclint:all,-html,-accessibility</additionalJOption>
-        </additionalJOptions>
-        <doclet>{doclet-class}</doclet>
+        <doclet>{asciidoclet-class}</doclet>
         <docletArtifact>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoclet</artifactId>
@@ -44,12 +39,17 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Ja
           --attribute "version=${project.version}"
           --attribute "title-link=https://example.com[${project.name} ${project.version}]"
         </additionalparam>
+        <additionalJOptions>
+            <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-Xdoclint:all,-html,-accessibility</additionalJOption>
+        </additionalJOptions>
     </configuration>
 </plugin>
 ----
 
+== Java 17+ example
+
 [source,xml,subs="attributes+"]
-.Java 17+
 ----
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
@@ -57,6 +57,19 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Ja
     <version>{maven-javadoc-plugin-version}</version>
     <configuration>
         <source>17</source>
+        <doclet>{asciidoclet-class}</doclet>
+        <docletArtifact>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoclet</artifactId>
+            <version>{asciidoclet-version}</version>
+        </docletArtifact>
+        <overview>src/main/java/overview.adoc</overview>
+        <additionalparam>
+          --base-dir ${project.basedir}
+          --attribute "name=${project.name}"
+          --attribute "version=${project.version}"
+          --attribute "title-link=https://example.com[${project.name} ${project.version}]"
+        </additionalparam>
         <additionalJOptions>
             <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
             <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
@@ -66,19 +79,6 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Ja
             <additionalJOption>-J--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
             <additionalJOption>-Xdoclint:all,-html,-accessibility</additionalJOption>
         </additionalJOptions>
-        <doclet>{doclet-class}</doclet>
-        <docletArtifact>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoclet</artifactId>
-            <version>{asciidoclet-version}</version>
-        </docletArtifact>
-        <overview>src/main/java/overview.adoc</overview>
-        <additionalparam>
-          --base-dir ${project.basedir}
-          --attribute "name=${project.name}"
-          --attribute "version=${project.version}"
-          --attribute "title-link=https://example.com[${project.name} ${project.version}]"
-        </additionalparam>
     </configuration>
 </plugin>
 ----
@@ -86,9 +86,11 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Ja
 == Gradle
 
 Asciidoclet may be used via a doclet in the `Javadoc` task:
+Pay special attention to `jFlags` to configure access to Java internals.
 
-[source,groovy]
-.Java 17+
+== Java 11 example
+
+[source,groovy,subs="attributes+"]
 ----
 plugins {
     id 'java'
@@ -99,13 +101,51 @@ configurations {
 }
 
 dependencies {
-    asciidoclet 'org.asciidoctor:asciidoclet:2.0.+'
+    asciidoclet 'org.asciidoctor:asciidoclet:{asciidoclet-version}'
 }
 
 javadoc {
     options {
         docletpath = configurations.asciidoclet.files.asType(List)
-        doclet = 'org.asciidoctor.asciidoclet.Asciidoclet'
+        doclet = '{asciidoclet-class}'
+        overview = "src/main/java/overview.adoc"
+        addStringOption "-base-dir", "${projectDir}" // <1>
+        addStringOption \
+            "-attribute", // <2>
+                "name=${project.name}," +
+                "version=${project.version}," +
+                "title-link=https://example.com[${project.name} ${project.version}]"
+        jFlags \
+            "--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"
+    }
+}
+----
+<1> Option names passed to Gradle's `javadoc` task must omit the leading "-", so here "-base-dir" means "--base-dir".
+ifdef::site-gen-antora[See xref:options.adoc[].]
+ifndef::site-gen-antora[See <<doclet-options>> below.]
+<2> Gradle's `javadoc` task does not allow multiple occurrences of the same option.
+Multiple attributes can be specified in a single string, separated by commas.
+
+== Java 17+ example
+
+[source,groovy,subs="attributes+"]
+----
+plugins {
+    id 'java'
+}
+
+configurations {
+    asciidoclet
+}
+
+dependencies {
+    asciidoclet 'org.asciidoctor:asciidoclet:{asciidoclet-version}'
+}
+
+javadoc {
+    options {
+        docletpath = configurations.asciidoclet.files.asType(List)
+        doclet = '{asciidoclet-class}'
         overview = "src/main/java/overview.adoc"
         addStringOption "-base-dir", "${projectDir}" // <1>
         addStringOption \

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -8,9 +8,12 @@ ifdef::site-gen-antora[xref:options.adoc[]]
 ifndef::site-gen-antora[<<doclet-options>> below]
 for supported options.
 
+NOTE: Asciidoclet must use some internal Java components.
+That requires the use of `exports` and `open` configurations.
+
 == Maven
 
-Asciidoclet may be used via a `maven-javadoc-plugin` doclet:
+Asciidoclet may be used via a `maven-javadoc-plugin` doclet for the supported Java versions
 
 [source,xml,subs="attributes+"]
 .Java 11
@@ -21,11 +24,53 @@ Asciidoclet may be used via a `maven-javadoc-plugin` doclet:
     <version>{maven-javadoc-plugin-version}</version>
     <configuration>
         <source>11</source>
+        <additionalJOptions>
+            <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-Xdoclint:all,-html,-accessibility</additionalJOption>
+        </additionalJOptions>
         <doclet>{doclet-class}</doclet>
         <docletArtifact>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoclet</artifactId>
-            <version>${asciidoclet.version}</version>
+            <version>{asciidoclet-version}</version>
+        </docletArtifact>
+        <overview>src/main/java/overview.adoc</overview>
+        <additionalparam>
+          --base-dir ${project.basedir}
+          --attribute "name=${project.name}"
+          --attribute "version=${project.version}"
+          --attribute "title-link=https://example.com[${project.name} ${project.version}]"
+        </additionalparam>
+    </configuration>
+</plugin>
+----
+
+[source,xml,subs="attributes+"]
+.Java 17+
+----
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>{maven-javadoc-plugin-version}</version>
+    <configuration>
+        <source>17</source>
+        <additionalJOptions>
+            <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-J--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
+            <additionalJOption>-Xdoclint:all,-html,-accessibility</additionalJOption>
+        </additionalJOptions>
+        <doclet>{doclet-class}</doclet>
+        <docletArtifact>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoclet</artifactId>
+            <version>{asciidoclet-version}</version>
         </docletArtifact>
         <overview>src/main/java/overview.adoc</overview>
         <additionalparam>

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -168,35 +168,3 @@ ifdef::site-gen-antora[See xref:options.adoc[].]
 ifndef::site-gen-antora[See <<doclet-options>> below.]
 <2> Gradle's `javadoc` task does not allow multiple occurrences of the same option.
 Multiple attributes can be specified in a single string, separated by commas.
-
-== Ant
-// Some of us still use Ant, alright?!
-Asciidoclet may be used via a doclet element in Ant's `javadoc` task:
-
-[source,xml]
-----
-<javadoc destdir="target/javadoc"
-         sourcepath="src"
-         overview="src/overview.adoc">
-  <doclet name="org.asciidoctor.asciidoclet.Asciidoclet" pathref="asciidoclet.classpath"> <!--1-->
-    <param name="--base-dir" value="${basedir}"/>
-    <param name="--attribute" value="name=${ant.project.name}"/>
-    <param name="--attribute" value="version=${version}"/>
-    <param name="--attribute" value="title-link=https://example.com[${ant.project.name} ${version}]"/>
-  </doclet>
-</javadoc>
-----
-
-<1> Assumes a path reference has been defined for Asciidoclet and its dependencies, e.g.
-using https://ant.apache.org/ivy/[Ivy^] or similar.
-
-// tag::warning-message[]
-[WARNING]
-====
-Currently, there is an intermittent benign warning message that is emitted during a run of Asciidoclet stating the following:
-
-  WARN: tilt autoloading 'tilt/haml' in a non thread-safe way; explicit require 'tilt/haml' suggested.
-
-Unfortunately, until the underlying library removes this warning message, it will be logged during the build.
-====
-// end::warning-message[]

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -1,25 +1,27 @@
 = Usage
+:doclet-class: org.asciidoctor.asciidoclet.Asciidoclet
+:maven-javadoc-plugin-version: 3.6.3
 
-Run Javadoc with the `org.asciidoctor.Asciidoclet` doclet class.
-Some examples for common build systems are shown below.
+Run Javadoc with the `{doclet-class}` doclet class as shown in the example below.
 See
 ifdef::site-gen-antora[xref:options.adoc[]]
-ifndef::site-gen-antora[<<doclet-options>> below ]
+ifndef::site-gen-antora[<<doclet-options>> below]
 for supported options.
 
 == Maven
 
 Asciidoclet may be used via a `maven-javadoc-plugin` doclet:
 
-[source,xml]
+[source,xml,subs="attributes+"]
+.Java 11
 ----
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-javadoc-plugin</artifactId>
-    <version>3.6.3</version>
+    <version>{maven-javadoc-plugin-version}</version>
     <configuration>
         <source>11</source>
-        <doclet>org.asciidoctor.asciidoclet.Asciidoclet</doclet>
+        <doclet>{doclet-class}</doclet>
         <docletArtifact>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoclet</artifactId>
@@ -47,18 +49,18 @@ configurations {
 }
 
 dependencies {
-    asciidoclet 'org.asciidoctor:asciidoclet:1.+'
+    asciidoclet 'org.asciidoctor:asciidoclet:2.0.+'
 }
 
 javadoc {
     options.docletpath = configurations.asciidoclet.files.asType(List)
-    options.doclet = 'org.asciidoctor.Asciidoclet'
+    options.doclet = 'org.asciidoctor.asciidoclet.Asciidoclet'
     options.overview = "src/main/java/overview.adoc"
     options.addStringOption "-base-dir", "${projectDir}" // <1>
     options.addStringOption "-attribute", // <2>
             "name=${project.name}," +
             "version=${project.version}," +
-            "title-link=https://example.com[${project.name} ${project.version}]")
+            "title-link=https://example.com[${project.name} ${project.version}]"
 }
 ----
 <1> Option names passed to Gradle's `javadoc` task must omit the leading "-", so here "-base-dir" means "--base-dir".
@@ -76,7 +78,7 @@ Asciidoclet may be used via a doclet element in Ant's `javadoc` task:
 <javadoc destdir="target/javadoc"
          sourcepath="src"
          overview="src/overview.adoc">
-  <doclet name="org.asciidoctor.Asciidoclet" pathref="asciidoclet.classpath"> <!--1-->
+  <doclet name="org.asciidoctor.asciidoclet.Asciidoclet" pathref="asciidoclet.classpath"> <!--1-->
     <param name="--base-dir" value="${basedir}"/>
     <param name="--attribute" value="name=${ant.project.name}"/>
     <param name="--attribute" value="version=${version}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -149,23 +149,15 @@
                     <target>11</target>
                     <compilerArgs>
                         <arg>--add-exports</arg>
-                        <arg>jdk.javadoc/jdk.javadoc.internal.api=asciidoclet</arg>
-                        <arg>--add-exports</arg>
-                        <arg>jdk.javadoc/jdk.javadoc.internal.tool=asciidoclet</arg>
+                        <arg>jdk.compiler/com.sun.tools.javac.model=asciidoclet</arg>
                         <arg>--add-exports</arg>
                         <arg>jdk.compiler/com.sun.tools.javac.parser=asciidoclet</arg>
                         <arg>--add-exports</arg>
                         <arg>jdk.compiler/com.sun.tools.javac.tree=asciidoclet</arg>
                         <arg>--add-exports</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.model=asciidoclet</arg>
+                        <arg>jdk.javadoc/jdk.javadoc.internal.tool=asciidoclet</arg>
                         <arg>--add-exports</arg>
                         <arg>jdk.compiler/com.sun.tools.javac.util=asciidoclet</arg>
-                        <arg>--add-exports</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                        <arg>--add-exports</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                        <arg>--add-exports</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>
@@ -177,7 +169,6 @@
                         --add-exports jdk.compiler/com.sun.tools.javac.parser=asciidoclet
                         --add-exports jdk.compiler/com.sun.tools.javac.util=asciidoclet
                         --add-opens jdk.compiler/com.sun.tools.javac.parser=asciidoclet
-                        --add-exports jdk.javadoc/jdk.javadoc.internal.tool=asciidoclet
                     </argLine>
                 </configuration>
             </plugin>

--- a/src/it/java-11/class-comments/pom.xml
+++ b/src/it/java-11/class-comments/pom.xml
@@ -21,9 +21,6 @@
 					<source>11</source>
 					<additionalJOptions>
 						<additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
-						<additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
-						<additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
-						<additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
 						<additionalJOption>-Xdoclint:all,-html,-accessibility</additionalJOption>
 					</additionalJOptions>
 					<doclet>org.asciidoctor.asciidoclet.Asciidoclet</doclet>

--- a/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorOptionsFactory.java
+++ b/src/main/java/org/asciidoctor/asciidoclet/AsciidoctorOptionsFactory.java
@@ -9,6 +9,11 @@ import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 
+/**
+ * Asciidoctor Options Factory.
+ *
+ * @since 2.0.0
+ */
 class AsciidoctorOptionsFactory {
 
     private static final String DEFAULT_BACKEND = "html5";


### PR DESCRIPTION
* Update Antora properties for v2.0.0
* Update usage with Maven Java 11 and 17+ examples
* Update usage with Gradle Java 11 and 17+ examples
* Remove Ant example. Given my experience trying to get it to work, I cannot recommend it. Most examples online don't work and are years old. Even if only for Javadoc I'd suggest anyone to set up Maven or Gradle nowadays.
* Update ITs to align with the examples.
* Replace incorrect "Asciidoc" mentioned by "AsciiDoc" in docs


Closes #127 