### PR TITLE
Escape attribute reference

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -109,7 +109,7 @@ javadoc {
         docletpath = configurations.asciidoclet.files.asType(List)
         doclet = '{asciidoclet-class}'
         overview = "src/main/java/overview.adoc"
-        addStringOption "-base-dir", "${projectDir}" // <1>
+        addStringOption "-base-dir", "$\{projectDir}" // <1>
         addStringOption \
             "-attribute", // <2>
                 "name=${project.name}," +
@@ -147,7 +147,7 @@ javadoc {
         docletpath = configurations.asciidoclet.files.asType(List)
         doclet = '{asciidoclet-class}'
         overview = "src/main/java/overview.adoc"
-        addStringOption "-base-dir", "${projectDir}" // <1>
+        addStringOption "-base-dir", "$\{projectDir}" // <1>
         addStringOption \
             "-attribute", // <2>
                 "name=${project.name}," +


### PR DESCRIPTION
`subs="attributes+"` was added to usage blocks and docs conversion attempts to read a grade property as if it were AsciiDoc. This PR scapes it.